### PR TITLE
Update footer to show dynamic Year

### DIFF
--- a/web/src/components/LandingPage/Footer.tsx
+++ b/web/src/components/LandingPage/Footer.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Github } from "lucide-react";
 
 const Footer = () => {
+  const currentYear = new Date().getFullYear()
   return (
     <footer id="footer" className="bg-black text-gray-400 py-12">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -87,7 +88,7 @@ const Footer = () => {
 
         {/* Copyright */}
         <p className="text-center text-xs pt-8 border-t border-gray-800 mt-8">
-          © 2025 THE STABLE ORDER. All rights reserved.
+          © {currentYear} THE STABLE ORDER. All rights reserved.
         </p>
       </div>
     </footer>


### PR DESCRIPTION
Static coded 2025 year
<img width="411" height="81" alt="image" src="https://github.com/user-attachments/assets/6bf9a734-1771-4ce8-9ed8-1146904ea866" />

Fix:
made dyanmic 

@KanishkSogani a small patch checkout 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year display to automatically reflect the current year without manual updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->