### PR TITLE
Fix: Override browser autofill styling to preserve dark theme on form inputs

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -37,6 +37,25 @@
   animation: fadeIn 0.5s ease forwards;
 }
 
+/* Override browser autofill styling for dark theme */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active,
+textarea:-webkit-autofill,
+textarea:-webkit-autofill:hover,
+textarea:-webkit-autofill:focus,
+textarea:-webkit-autofill:active,
+select:-webkit-autofill,
+select:-webkit-autofill:hover,
+select:-webkit-autofill:focus,
+select:-webkit-autofill:active {
+  -webkit-box-shadow: 0 0 0 1000px #3a3a3a inset !important;
+  -webkit-text-fill-color: #ffffff !important;
+  caret-color: #ffffff !important;
+  transition: background-color 5000s ease-in-out 0s;
+}
+
 body {
   font-family: Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
###  Addressed Issues:

Fixes #(TODO:issue number)

### Description

Browser autofill (Chrome, Edge, Safari) forcefully injects a light blue/white background (`#e8f0fe`) on autofilled `<input>` and `<textarea>` fields via the `:-webkit-autofill` pseudo-class. This overrides the app's dark theme styling (`bg-[#3a3a3a]`), causing a jarring visual break on the Dashboard profile form and the Write Testimonial page whenever a user selects an autofill suggestion.

### Root Cause

Chromium-based browsers apply an internal user-agent stylesheet rule:
```css
input:-webkit-autofill {
  background-color: #e8f0fe !important;
}
```
This cannot be overridden with a normal `background-color` rule. The only reliable workaround is using the `-webkit-box-shadow` inset trick to visually cover the autofill background.

### Changes Made

Added autofill override styles in `globals.css` targeting all autofill states (`hover`, `focus`, `active`) for `input`, `textarea`, and `select` elements:

- **`-webkit-box-shadow: 0 0 0 1000px #3a3a3a inset`** — Covers the browser-injected background with the app's dark input color
- **`-webkit-text-fill-color: #ffffff`** — Keeps text white (Chrome also overrides text color on autofill)
- **`caret-color: #ffffff`** — Ensures the cursor remains visible
- **`transition: background-color 5000s`** — Delays Chrome's background transition so it never visually appears

### Affected Pages

- `/dashboard` — Profile edit form (Name, Contact, Bio fields)
- `/write` — Write testimonial form (Giver Name, Profile URL fields)


### Screenshots/Recordings:

**Before**
<img width="1554" height="145" alt="Screenshot 2026-04-18 152648" src="https://github.com/user-attachments/assets/45072f49-f6f3-4035-af03-43f52d6897e5" />

**After**

https://github.com/user-attachments/assets/8456a630-7e87-4dac-a644-6dfb8e74b4ff

### Additional Notes:

- This is a CSS-only fix — **zero JavaScript changes**, no component modifications
- Uses the widely-adopted `-webkit-box-shadow` inset trick, which is the standard approach used by Material UI, Chakra UI, and other design systems for dark-themed autofill handling
- The `#3a3a3a` color matches the existing `bg-[#3a3a3a]` used across all input fields in the app
- Tested on Chrome and Edge (Chromium-based browsers where this issue occurs)

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [x] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual styling of autofilled form fields, including inputs, text areas, and dropdowns, with dark backgrounds and white text for enhanced contrast and readability across all interactive states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->