### PR TITLE
refactor: replace require strings with custom errors for gas optimiza…

### DIFF
--- a/contracts/src/VouchMe.sol
+++ b/contracts/src/VouchMe.sol
@@ -64,6 +64,19 @@ contract VouchMe is ERC721URIStorage, Ownable, ReentrancyGuard {
     event FreeThresholdUpdated(uint256 oldThreshold, uint256 newThreshold);
     event FeePaid(address indexed payer, uint256 amount);
     
+    // Custom errors for gas-efficient reverts
+    error InvalidSignature();
+    error TestimonialDoesNotExist();
+    error TestimonialHasBeenDeleted();
+    error TokensAreNonTransferrable();
+    error OnlyRecipientCanDelete();
+    error TestimonialAlreadyDeleted();
+    error InsufficientFeePayment();
+    error FeeTransferFailed();
+    error RefundFailed();
+    error SetTreasuryBeforeEnablingFees();
+    error TreasuryCannotBeZeroAddress();
+    
     constructor() ERC721("VouchMe Testimonial", "VOUCH") Ownable(msg.sender) {
         // Initialize with monetization disabled
         treasury = address(0);
@@ -102,7 +115,7 @@ contract VouchMe is ERC721URIStorage, Ownable, ReentrancyGuard {
         
         // Verify the signature matches the sender
         address recoveredSigner = ethSignedMessageHash.recover(signature);
-        require(recoveredSigner == senderAddress, "Invalid signature");
+        if (recoveredSigner != senderAddress) revert InvalidSignature();
 
         // Check if there's an existing testimonial from this sender to this receiver
         uint256 existingTokenId = _testimonial[senderAddress][msg.sender];
@@ -117,7 +130,7 @@ contract VouchMe is ERC721URIStorage, Ownable, ReentrancyGuard {
         uint256 currentCount = _receivedTestimonials[msg.sender].length;
         uint256 requiredFee = _calculateRequiredFee(currentCount);
         if (requiredFee > 0) {
-            require(msg.value >= requiredFee, "Insufficient fee payment");
+            if (msg.value < requiredFee) revert InsufficientFeePayment();
         } else if (msg.value > 0) {
             // No fee is required, so any payment should be refunded later
         }
@@ -165,17 +178,17 @@ contract VouchMe is ERC721URIStorage, Ownable, ReentrancyGuard {
         // Interactions: transfer fee/refund only after all state changes and events above.
         if (requiredFee > 0) {
             (bool sent, ) = treasury.call{value: requiredFee}("");
-            require(sent, "Fee transfer failed");
+            if (!sent) revert FeeTransferFailed();
             emit FeePaid(msg.sender, requiredFee);
 
             uint256 excess = msg.value - requiredFee;
             if (excess > 0) {
                 (bool refunded, ) = msg.sender.call{value: excess}("");
-                require(refunded, "Refund failed");
+                if (!refunded) revert RefundFailed();
             }
         } else if (msg.value > 0) {
             (bool refunded, ) = msg.sender.call{value: msg.value}("");
-            require(refunded, "Refund failed");
+            if (!refunded) revert RefundFailed();
         }
         
         return newTokenId;
@@ -196,12 +209,12 @@ contract VouchMe is ERC721URIStorage, Ownable, ReentrancyGuard {
      * @return Testimonial struct containing details
      */
     function getTestimonialDetails(uint256 tokenId) external view returns (Testimonial memory) {
-        require(_ownerOf(tokenId) != address(0), "Testimonial does not exist");
+        if (_ownerOf(tokenId) == address(0)) revert TestimonialDoesNotExist();
         
         // Check if the testimonial exists in the contract state
         address sender = _testimonials[tokenId].sender;
         address receiver = _testimonials[tokenId].receiver;
-        require(_testimonial[sender][receiver] == tokenId, "Testimonial has been deleted");
+        if (_testimonial[sender][receiver] != tokenId) revert TestimonialHasBeenDeleted();
         
         return _testimonials[tokenId];
     }
@@ -258,7 +271,7 @@ contract VouchMe is ERC721URIStorage, Ownable, ReentrancyGuard {
      * @dev Prevents token transfers by allowing only minting.
      */
     function _update(address to, uint256 tokenId, address auth) internal override returns (address) {
-        require(_ownerOf(tokenId) == address(0), "Tokens are non-transferrable");
+        if (_ownerOf(tokenId) != address(0)) revert TokensAreNonTransferrable();
 
         return super._update(to, tokenId, auth);
     }
@@ -345,11 +358,11 @@ contract VouchMe is ERC721URIStorage, Ownable, ReentrancyGuard {
      * @param tokenId The token ID to delete
      */
     function deleteTestimonial(uint256 tokenId) external {
-        require(_ownerOf(tokenId) == msg.sender, "Only recipient can delete");
+        if (_ownerOf(tokenId) != msg.sender) revert OnlyRecipientCanDelete();
         
         // Check if the testimonial still exists
         address sender = _testimonials[tokenId].sender;
-        require(_testimonial[sender][msg.sender] == tokenId, "Testimonial already deleted");
+        if (_testimonial[sender][msg.sender] != tokenId) revert TestimonialAlreadyDeleted();
         
         _removeTestimonialFromList(tokenId, sender, msg.sender);
         
@@ -366,7 +379,7 @@ contract VouchMe is ERC721URIStorage, Ownable, ReentrancyGuard {
      */
     function setFee(uint256 _fee) external onlyOwner {
         // If setting a non-zero fee, treasury must be set first
-        require(_fee == 0 || treasury != address(0), "Set treasury before enabling fees");
+        if (_fee != 0 && treasury == address(0)) revert SetTreasuryBeforeEnablingFees();
         
         uint256 oldFee = fee;
         fee = _fee;
@@ -378,7 +391,7 @@ contract VouchMe is ERC721URIStorage, Ownable, ReentrancyGuard {
      * @param _treasury The treasury address
      */
     function setTreasury(address _treasury) external onlyOwner {
-        require(_treasury != address(0), "Treasury cannot be zero address");
+        if (_treasury == address(0)) revert TreasuryCannotBeZeroAddress();
         
         address oldTreasury = treasury;
         treasury = _treasury;

--- a/contracts/test/VouchMe.t.sol
+++ b/contracts/test/VouchMe.t.sol
@@ -208,7 +208,7 @@ contract VouchMeTest is Test {
         assertEq(existingTokenId, secondTokenId);
         
         // Verify old testimonial is deleted
-        vm.expectRevert("Testimonial has been deleted");
+        vm.expectRevert(VouchMe.TestimonialHasBeenDeleted.selector);
         vouchMe.getTestimonialDetails(firstTokenId);
         
         // Verify new testimonial is accessible
@@ -235,13 +235,13 @@ contract VouchMeTest is Test {
         (bool exists,) = vouchMe.hasExistingTestimonial(bob, alice);
         assertFalse(exists);
         
-        vm.expectRevert("Testimonial has been deleted");
+        vm.expectRevert(VouchMe.TestimonialHasBeenDeleted.selector);
         vouchMe.getTestimonialDetails(tokenId);
     }
 
     function testCannotDeleteNonExistentTestimonial() public {
         vm.prank(alice);
-        vm.expectRevert("Only recipient can delete");
+        vm.expectRevert(VouchMe.OnlyRecipientCanDelete.selector);
         vouchMe.deleteTestimonial(999);
     }
 
@@ -249,7 +249,7 @@ contract VouchMeTest is Test {
         uint256 tokenId = createTestimonial(bob, alice, CONTENT, GIVER_NAME, PROFILE_URL);
         
         vm.prank(bob); // Bob tries to delete Alice's testimonial
-        vm.expectRevert("Only recipient can delete");
+        vm.expectRevert(VouchMe.OnlyRecipientCanDelete.selector);
         vouchMe.deleteTestimonial(tokenId);
     }
 
@@ -262,7 +262,7 @@ contract VouchMeTest is Test {
         
         // Try to delete again
         vm.prank(alice);
-        vm.expectRevert("Testimonial already deleted");
+        vm.expectRevert(VouchMe.TestimonialAlreadyDeleted.selector);
         vouchMe.deleteTestimonial(tokenId);
     }
 
@@ -323,7 +323,7 @@ contract VouchMeTest is Test {
         
         // This should revert due to signature verification failure
         vm.prank(alice);
-        vm.expectRevert("Invalid signature");
+        vm.expectRevert(VouchMe.InvalidSignature.selector);
         vouchMe.createTestimonial(address(0), CONTENT, GIVER_NAME, PROFILE_URL, signature);
     }
 
@@ -369,12 +369,12 @@ contract VouchMeTest is Test {
         
         // Try to transfer from Alice to Charlie
         vm.prank(alice);
-        vm.expectRevert("Tokens are non-transferrable");
+        vm.expectRevert(VouchMe.TokensAreNonTransferrable.selector);
         vouchMe.transferFrom(alice, charlie, tokenId);
         
         // Try safeTransferFrom
         vm.prank(alice);
-        vm.expectRevert("Tokens are non-transferrable");
+        vm.expectRevert(VouchMe.TokensAreNonTransferrable.selector);
         vouchMe.safeTransferFrom(alice, charlie, tokenId);
     }
 }

--- a/contracts/test/VouchMeFuzz.t.sol
+++ b/contracts/test/VouchMeFuzz.t.sol
@@ -123,7 +123,7 @@ contract VouchMeFuzzTest is TestHelpers {
         assertEq(vouchMe.getTestimonialCount(receiver), 1);
         
         // Old testimonial should be deleted
-        vm.expectRevert("Testimonial has been deleted");
+        vm.expectRevert(VouchMe.TestimonialHasBeenDeleted.selector);
         vouchMe.getTestimonialDetails(tokenId1);
         
         // New testimonial should be accessible
@@ -170,7 +170,7 @@ contract VouchMeFuzzTest is TestHelpers {
         assertEq(vouchMe.getTestimonialCount(receiver), numTestimonials - 1);
         
         // Verify the deleted testimonial is not accessible
-        vm.expectRevert("Testimonial has been deleted");
+        vm.expectRevert(VouchMe.TestimonialHasBeenDeleted.selector);
         vouchMe.getTestimonialDetails(tokenIds[deleteIndex]);
         
         // Verify remaining testimonials are still accessible

--- a/contracts/test/VouchMeIntegration.t.sol
+++ b/contracts/test/VouchMeIntegration.t.sol
@@ -113,7 +113,7 @@ contract VouchMeIntegrationTest is TestHelpers {
         assertEq(vouchMe.getTestimonialCount(alice), 2);
         
         // The old testimonial should be inaccessible
-        vm.expectRevert("Testimonial has been deleted");
+        vm.expectRevert(VouchMe.TestimonialHasBeenDeleted.selector);
         vouchMe.getTestimonialDetails(tokenId1);
         
         // The new testimonial should be accessible
@@ -272,7 +272,7 @@ contract VouchMeIntegrationTest is TestHelpers {
         );
         
         // Old testimonial should be replaced
-        vm.expectRevert("Testimonial has been deleted");
+        vm.expectRevert(VouchMe.TestimonialHasBeenDeleted.selector);
         vouchMe.getTestimonialDetails(tokenId);
         
         // New testimonial should be accessible

--- a/contracts/test/VouchMeMonetization.t.sol
+++ b/contracts/test/VouchMeMonetization.t.sol
@@ -169,7 +169,7 @@ contract VouchMeMonetizationTest is Test {
     }
     
     function testSetTreasuryRevertsForZeroAddress() public {
-        vm.expectRevert("Treasury cannot be zero address");
+        vm.expectRevert(VouchMe.TreasuryCannotBeZeroAddress.selector);
         vouchMe.setTreasury(address(0));
     }
     
@@ -191,7 +191,7 @@ contract VouchMeMonetizationTest is Test {
     }
     
     function testSetFeeRevertsWithoutTreasury() public {
-        vm.expectRevert("Set treasury before enabling fees");
+        vm.expectRevert(VouchMe.SetTreasuryBeforeEnablingFees.selector);
         vouchMe.setFee(0.001 ether);
     }
     
@@ -319,7 +319,7 @@ contract VouchMeMonetizationTest is Test {
         bytes memory signature = createValidSignature(bob, alice, CONTENT, GIVER_NAME, PROFILE_URL);
         
         vm.prank(alice);
-        vm.expectRevert("Insufficient fee payment");
+        vm.expectRevert(VouchMe.InsufficientFeePayment.selector);
         vouchMe.createTestimonial{value: 0.005 ether}(bob, CONTENT, GIVER_NAME, PROFILE_URL, signature);
     }
     
@@ -385,7 +385,7 @@ contract VouchMeMonetizationTest is Test {
         bytes memory signature = createValidSignature(bob, alice, CONTENT, GIVER_NAME, PROFILE_URL);
 
         vm.prank(alice);
-        vm.expectRevert("Fee transfer failed");
+        vm.expectRevert(VouchMe.FeeTransferFailed.selector);
         vouchMe.createTestimonial{value: 0.01 ether}(bob, CONTENT, GIVER_NAME, PROFILE_URL, signature);
     }
 
@@ -406,7 +406,7 @@ contract VouchMeMonetizationTest is Test {
             PROFILE_URL
         );
 
-        vm.expectRevert("Refund failed");
+        vm.expectRevert(VouchMe.RefundFailed.selector);
         rejectingReceiver.submitTestimonial{value: 0.02 ether}(
             vouchMe,
             bob,

--- a/contracts/test/VouchMeSignature.t.sol
+++ b/contracts/test/VouchMeSignature.t.sol
@@ -54,7 +54,7 @@ contract VouchMeSignatureTest is TestHelpers {
         );
         
         vm.prank(alice);
-        vm.expectRevert("Invalid signature");
+        vm.expectRevert(VouchMe.InvalidSignature.selector);
         vouchMe.createTestimonial(bob, CONTENT, GIVER_NAME, PROFILE_URL, invalidSignature);
     }
 
@@ -66,7 +66,7 @@ contract VouchMeSignatureTest is TestHelpers {
         
         // Try to use signature with different content
         vm.prank(alice);
-        vm.expectRevert("Invalid signature");
+        vm.expectRevert(VouchMe.InvalidSignature.selector);
         vouchMe.createTestimonial(bob, "Tampered content", GIVER_NAME, PROFILE_URL, signature);
     }
 
@@ -78,7 +78,7 @@ contract VouchMeSignatureTest is TestHelpers {
         
         // Charlie tries to use the signature
         vm.prank(charlie);
-        vm.expectRevert("Invalid signature");
+        vm.expectRevert(VouchMe.InvalidSignature.selector);
         vouchMe.createTestimonial(bob, CONTENT, GIVER_NAME, PROFILE_URL, signature);
     }
 


### PR DESCRIPTION
### Addressed Issues:

Fixes #39 

### Screenshots/Recordings:

*Not applicable. This is a smart contract optimization PR that does not affect the frontend UI.*

### Additional Notes:
This PR implements a major gas optimization refactor across the `VouchMe` smart contract. 
- Replaced 12 `require(condition, "string")` statements with `if (!condition) revert CustomError();` patterns.
- Defined 11 semantic custom errors at the contract level (e.g., `InvalidSignature()`, `TestimonialDoesNotExist()`).
- Using custom errors is significantly cheaper (often ~60% less gas for reverts) because it avoids storing string messages in the contract bytecode.
- Updated 20 `vm.expectRevert()` statements across 5 test files to properly catch the new error selectors.
- **Verification:** All 65 tests in the Hardhat/Foundry suite are passing successfully. No merge conflicts with the struct-packing changes.

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: **Claude opus 4.6 via Antigravity**

## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated contract error handling to use custom error codes instead of string-based messages for signature validation, testimonial management, payment processing, and treasury operations.

* **Tests**
  * All test suites updated to validate custom error codes across signature verification, testimonial operations, payment handling, and monetization scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StabilityNexus/VouchMe/pull/42)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->